### PR TITLE
Fix surface parts jumping on compress

### DIFF
--- a/Source/Konstruction/Konstruction/NodeUtilities.cs
+++ b/Source/Konstruction/Konstruction/NodeUtilities.cs
@@ -36,7 +36,7 @@ namespace Konstruction
 
             thisPart.UpdateOrgPosAndRot(thisPart.vessel.rootPart);
 
-            foreach (var p in thisPart.children)
+            foreach (var p in thisPart.children.Where(p => p.attachMode == AttachModes.STACK))
                 MovePart(p, offset);
         }
 


### PR DESCRIPTION
This change fixes surface attached parts being incorrectly offset when compressing docking ports.